### PR TITLE
Loosen install_requires entry to requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setuptools.setup(
     url="https://github.com/dahlke/terrasnek",
     packages=setuptools.find_packages(),
     install_requires=[
-        "requests==2.21.0"
+        "requests>=2.21.0"
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
Generally, when leveraging setuptools, it is a good practice to keep any explicit requirements as loose as possible:

> It is not considered best practice to use install_requires to pin dependencies to specific versions, or to specify sub-dependencies (i.e. dependencies of your dependencies). This is overly-restrictive, and prevents the user from gaining the benefit of dependency upgrades.

(via https://packaging.python.org/discussions/install-requires-vs-requirements/#id5)

In particular, this change would help prevent issues such as the one I encountered just now 😛:

```
%▶ pip-compile <(echo -e "boto3\nterrasnek")                  
Could not find a version that matches urllib3<1.25,<1.27,>=1.21.1,>=1.25.4 (from botocore==1.20.17->boto3==1.17.17->-r /dev/fd/11 (line 1))
Tried: 0.3, 1.0, 1.0.1, 1.0.2, 1.1, 1.2, 1.2.1, 1.2.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.7.1, 1.8, 1.8.2, 1.8.3, 1.9, 1.9.1, 1.10, 1.10.1, 1.10.2, 1.10.3, 1.10.4, 1.11, 1.11, 1.12, 1.12, 1.13, 1.13, 1.13.1, 1.13.1, 1.14, 1.14, 1.15, 1.15, 1.15.1, 1.15.1, 1.16, 1.16, 1.17, 1.17, 1.18, 1.18, 1.18.1, 1.18.1, 1.19, 1.19, 1.19.1, 1.19.1, 1.20, 1.20, 1.21, 1.21, 1.21.1, 1.21.1, 1.22, 1.22, 1.23, 1.23, 1.24, 1.24, 1.24.1, 1.24.1, 1.24.2, 1.24.2, 1.24.3, 1.24.3, 1.25, 1.25, 1.25.1, 1.25.1, 1.25.2, 1.25.2, 1.25.3, 1.25.3, 1.25.4, 1.25.4, 1.25.5, 1.25.5, 1.25.6, 1.25.6, 1.25.7, 1.25.7, 1.25.8, 1.25.8, 1.25.9, 1.25.9, 1.25.10, 1.25.10, 1.25.11, 1.25.11, 1.26.0, 1.26.0, 1.26.1, 1.26.1, 1.26.2, 1.26.2, 1.26.3, 1.26.3
There are incompatible versions in the resolved dependencies:
  urllib3<1.25,>=1.21.1 (from requests==2.21.0->terrasnek==0.1.1->-r /dev/fd/11 (line 2))
  urllib3<1.27,>=1.25.4 (from botocore==1.20.17->boto3==1.17.17->-r /dev/fd/11 (line 1))
``` 