### PR TITLE
Update requests to 2.22.0

### DIFF
--- a/pip-reqs.txt
+++ b/pip-reqs.txt
@@ -1,4 +1,4 @@
-requests==2.21.0
+requests==2.22.0
 pylint==2.3.1
 coverage==4.5.4
 coverage-badge==1.0.1


### PR DESCRIPTION
Terrasnek is currently pinned to requests 2.21.0 which is incompatible with another package we use `python-gitlab`. This MR updates Terrasnek to the latest compatible version.

I did review your contributing documentation, and it looks like there is not much for me to do without being able to run the unit test suit. Let me know if there is anything I missed though and I'll gladly take care of it.