### PR TITLE
Adding search parameter to Workspaces.list_all() API

### DIFF
--- a/terrasnek/workspaces.py
+++ b/terrasnek/workspaces.py
@@ -98,7 +98,7 @@ class TFCWorkspaces(TFCEndpoint):
 
         Returns an object with two arrays of objects.
         """
-        return self._list_all(self._org_api_v2_base_url, search=None, include=include)
+        return self._list_all(self._org_api_v2_base_url, search=search, include=include)
 
     def show(self, workspace_name=None, workspace_id=None, include=None):
         """

--- a/test/workspaces_test.py
+++ b/test/workspaces_test.py
@@ -55,7 +55,7 @@ class TestTFCWorkspaces(TestTFCBaseTestCase):
 
         # Test the search parameter on list all workspaces parameter
         search_listed_ws = self._api.workspaces.list_all(page=PAGE_START, page_size=PAGE_SIZE, search=ws_name)["data"]
-        self.assertTrue(len(search_listed_ws), 1)
+        self.assertTrue(ws_name in [ws["attributes"]["name"] for ws in search_listed_ws])
 
         found_ws = False
         for workspace in all_ws["data"]:

--- a/test/workspaces_test.py
+++ b/test/workspaces_test.py
@@ -41,6 +41,9 @@ class TestTFCWorkspaces(TestTFCBaseTestCase):
         search_listed_ws = self._api.workspaces.list(page=PAGE_START, page_size=PAGE_SIZE, search=ws_name)["data"]
         self.assertTrue(len(search_listed_ws), 1)
 
+        # Ensure searched workspace is in the returned list
+        self.assertTrue(ws_name in [ws["attributes"]["name"] for ws in search_listed_ws])
+
         listed_ws = listed_ws_raw["data"]
         found_ws = False
         for workspace in listed_ws:
@@ -54,8 +57,11 @@ class TestTFCWorkspaces(TestTFCBaseTestCase):
         self.assertIn("included", all_ws)
 
         # Test the search parameter on list all workspaces parameter
-        search_listed_ws = self._api.workspaces.list_all(page=PAGE_START, page_size=PAGE_SIZE, search=ws_name)["data"]
-        self.assertTrue(ws_name in [ws["attributes"]["name"] for ws in search_listed_ws])
+        search_listed_ws_all = self._api.workspaces.list_all(page=PAGE_START, page_size=PAGE_SIZE, search=ws_name)["data"]
+        self.assertTrue(len(search_listed_ws_all), 1)
+
+        # Ensure searched workspace is in the returned list
+        self.assertTrue(ws_name in [ws["attributes"]["name"] for ws in search_listed_ws_all])
 
         found_ws = False
         for workspace in all_ws["data"]:

--- a/test/workspaces_test.py
+++ b/test/workspaces_test.py
@@ -53,6 +53,10 @@ class TestTFCWorkspaces(TestTFCBaseTestCase):
         all_ws = self._api.workspaces.list_all(include=["organization"])
         self.assertIn("included", all_ws)
 
+        # Test the search parameter on list all workspaces parameter
+        search_listed_ws = self._api.workspaces.list_all(page=PAGE_START, page_size=PAGE_SIZE, search=ws_name)["data"]
+        self.assertTrue(len(search_listed_ws), 1)
+
         found_ws = False
         for workspace in all_ws["data"]:
             if workspace["id"] == ws_id:


### PR DESCRIPTION
Referencing: 
Fixes #28 

I can see your existing 0.1.9 release added the search parameter to the `list()` endpoint for workspaces, but not `list_all()`.

At a glance, your meta endpoint class seems to support search for list_all so I assume this is the right implementation?