### PR TITLE
Properly handle the well-known tfe.v2 backslash if not present.

### DIFF
--- a/terrasnek/endpoint.py
+++ b/terrasnek/endpoint.py
@@ -32,7 +32,7 @@ class TFCEndpoint(ABC):
 
         self._instance_url = \
             instance_url if instance_url[-1] != "/" else instance_url[:-1]
-        self._api_v2_base_url = f"{self._instance_url}{well_known_paths['tfe.v2'][:-1]}"
+        self._api_v2_base_url = f"{self._instance_url}{well_known_paths['tfe.v2'] if well_known_paths['tfe.v2'][-1] != '/' else well_known_paths['tfe.v2'][:-1]}"
         self._meta_base_url = f"{self._instance_url}/api/meta"
         self._mods_v1_base_url = f"{self._instance_url}{well_known_paths['modules.v1'][:-1]}"
         # TODO: support the public registry workflows?


### PR DESCRIPTION
OTF (a TFC open source clone) well-known/terraform.json file tfe.v2 entries differs a bit from TFC. i.e.
OTF: "tfe.v2":"/api/v2"
TFC: "tfe.v2":"/api/v2/"
This is explained here https://github.com/leg100/otf/issues/474
This change handles this scenario as well as making the code more resilient in case TFC decides to remove the ending slash at some future time. Also note the code is properly handling the ending slash in the previous line.